### PR TITLE
trigger FLAlertLayer::keyBackClicked() on PaginatedFLAlert::keyBackClicked()

### DIFF
--- a/src/layers/PaginatedFLAlert.cpp
+++ b/src/layers/PaginatedFLAlert.cpp
@@ -60,6 +60,7 @@ bool PaginatedFLAlert::init(const std::string& title, const std::vector<std::str
 
 void PaginatedFLAlert::keyBackClicked() {
     onClose(this);
+    FLAlertLayer::keyBackClicked();
 }
 
 void PaginatedFLAlert::onNext(cocos2d::CCObject* sender) {


### PR DESCRIPTION
allow other mods to detect when PaginatedFLAlert closes instead of switching pages