### PR TITLE
Event info in stars in-depth display

### DIFF
--- a/src/hooks/DemonInfoPopup.cpp
+++ b/src/hooks/DemonInfoPopup.cpp
@@ -25,13 +25,24 @@ class BI_DLL $modify(BIDemonInfoPopup, DemonInfoPopup) {
             if(userInfo->m_demons <= sum) return true;
 
             if(auto menu = m_mainLayer->getChildByID("bottom-left-menu")) {
-                auto text = CCLabelBMFont::create(
+                auto deratedLabel = CCLabelBMFont::create(
                     fmt::format("Derated: {}", userInfo->m_demons - sum).c_str(),
                     "goldFont.fnt"
                 );
 
-                menu->addChild(text);
-                menu->updateLayout();
+                deratedLabel->setID("derated-label"_spr);
+                menu->addChild(deratedLabel);
+            	menu->updateLayout();
+
+            	int eventLevels = BetterInfo::countCompletedEventLevels(true);
+            	if (eventLevels < 0) return true;
+
+            	auto eventLevelsLabel = BetterInfo::createEventLevelsLabel(eventLevels);
+            	if (!eventLevelsLabel) return true;
+
+            	eventLevelsLabel->setID("demons-event-text"_spr);
+            	menu->addChild(eventLevelsLabel);
+            	menu->updateLayout();
             }
         }
 

--- a/src/hooks/StarInfoPopup.cpp
+++ b/src/hooks/StarInfoPopup.cpp
@@ -1,0 +1,29 @@
+#include <Geode/Geode.hpp>
+#include <Geode/modify/StarInfoPopup.hpp>
+
+#include "../utils.hpp"
+
+using namespace geode::prelude;
+
+class BI_DLL $modify(BIStarInfoPopup, StarInfoPopup) {
+	bool init(int a, int b, int c, int d, int e, int f, int gauntlet, int daily, int unknown, bool platformer) {
+		if (!StarInfoPopup::init(a,b,c,d,e,f,gauntlet,daily,unknown,platformer)) return false;
+
+		if (platformer) return true;
+
+		int eventLevels = BetterInfo::countCompletedEventLevels(false);
+		if (eventLevels < 0) return true;
+
+		auto eventLevelsLabel = BetterInfo::createEventLevelsLabel(eventLevels);
+		if (!eventLevelsLabel) return true;
+
+		auto menu = m_mainLayer->getChildByID("bottom-right-menu");
+		if (!menu) return true;
+
+		eventLevelsLabel->setID("event-text"_spr);
+		menu->addChild(eventLevelsLabel);
+		menu->updateLayout();
+
+		return true;
+	}
+};

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1071,3 +1071,21 @@ void BetterInfo::fixOversizedPopup(FLAlertLayer* node) {
         node->addChild(newLayerColor, -1);
     }
 }
+
+int BetterInfo::countCompletedEventLevels(bool demon) {
+    auto glm = GameLevelManager::sharedState();
+    if (!glm || !glm->m_dailyLevels) return -1;
+    int eventLevels = 0;
+    for (auto [id, level] : CCDictionaryExt<std::string, GJGameLevel*>(glm->m_dailyLevels)) {
+        if (level->m_normalPercent.value() < 100 || !GameStatsManager::sharedState()->hasCompletedLevel(level)) continue;
+        if (!demon && level->m_stars.value() > 9) continue;
+        if (demon && level->m_stars.value() < 10) continue;
+        if (level->m_dailyID >= 200000) eventLevels++;
+    }
+    return eventLevels;
+}
+
+CCLabelBMFont* BetterInfo::createEventLevelsLabel(int count) {
+    if (count < 0) return nullptr;
+    return CCLabelBMFont::create(fmt::format("Event: {}", count).c_str(), "goldFont.fnt");
+}

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -100,4 +100,7 @@ namespace BetterInfo {
     BI_DLL void cancelUnimportantNotifications();
 
     BI_DLL void fixOversizedPopup(FLAlertLayer* node);
+
+    BI_DLL int countCompletedEventLevels(bool demon);
+    BI_DLL CCLabelBMFont* createEventLevelsLabel(int count);
 }


### PR DESCRIPTION
Depends on https://github.com/geode-sdk/NodeIDs/pull/115

also applied to demoninfopopup, but moved to lower left corner to "indicate" that it shouldnt be part of any official totals