### PR TITLE
add filter for levels with ncs songs

### DIFF
--- a/src/hooks/GameLevelManager.cpp
+++ b/src/hooks/GameLevelManager.cpp
@@ -185,6 +185,7 @@ class BI_DLL $modify(GameLevelManager) {
             .unepic = Mod::get()->getSavedValue<bool>("user_search_noepic"),
             .starRange = createRangeOption("user_search_starrange"),
             .gameVersion = createRangeOption("user_search_gameversion"),
+            .ncs = Mod::get()->getSavedValue<bool>("user_search_ncs"),
         };
         
         //calculating levels
@@ -219,6 +220,7 @@ class BI_DLL $modify(GameLevelManager) {
                 if(searchObj.songCustom && level->m_songID != searchObj.songID) continue;
                 if(!searchObj.songCustom && (level->m_songID != 0 || level->m_audioTrack != searchObj.songID)) continue;
             }
+            if(searchObj.ncs && !BetterInfo::isNCSSong(level->m_songID)) continue;
             if(searchObj.noStar && level->m_stars != 0) continue;
             if(searchObj.verifiedCoins && (level->m_coinsVerified == 0)) continue;
             if(searchObj.unverifiedCoins && (level->m_coinsVerified)) continue;

--- a/src/layers/LevelFiltering/ProfileSearchOptions.cpp
+++ b/src/layers/LevelFiltering/ProfileSearchOptions.cpp
@@ -329,7 +329,7 @@ void ProfileSearchOptions::drawTogglesSecondary(){
     createToggle("twoplayer", "2-Player");
     createToggle("gameversion", "Game Ver.", menu_selector(ProfileSearchOptions::onGameVersionRange));
     createToggle("unverifiedcoins", "Unverified Coins");
-    
+    createToggle("ncs", "NCS Song");
 }
 
 void ProfileSearchOptions::drawTogglesTerciary(){
@@ -494,6 +494,8 @@ BISearchObject ProfileSearchOptions::getSearchObject() {
     setToRangeItem(searchObj.starRange, "starrange");
     setToRangeItem(searchObj.gameVersion, "gameversion");
 
+    searchObj.ncs = getOption("ncs");
+
     return searchObj;
 }
 
@@ -561,6 +563,8 @@ void ProfileSearchOptions::setSearchObject(const BISearchObject& searchObj) {
     setOption("favorite", searchObj.favorite);
     setFromRangeItem("starrange", searchObj.starRange);
     setFromRangeItem("gameversion", searchObj.gameVersion);
+
+    setOption("ncs", searchObj.ncs);
 
     destroyToggles();
     drawToggles();

--- a/src/objects/BISearchObject.h
+++ b/src/objects/BISearchObject.h
@@ -53,4 +53,5 @@ struct BISearchObject {
         bool favorite = false;
         RangeItem starRange;
         RangeItem gameVersion = {false, 0, 22};
+        bool ncs = false;
 };

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -293,6 +293,13 @@ bool BetterInfo::isNewGrounds(int audioID) {
     return BetterInfo::getSongUrl(audioID).find("://audio.ngfiles.com/") != std::string::npos;
 }
 
+bool BetterInfo::isNCSSong(int audioID) {
+    if(audioID == 0) return false;
+
+    auto songInfo = static_cast<SongInfoObject*>(MusicDownloadManager::sharedState()->m_songObjects->objectForKey(std::to_string(audioID)));
+    return songInfo && songInfo->m_nongType == 1;
+}
+
 /*
     This is a reimplementation of GameLevelManager::responseToDict
     because I couldn't get it to work. It's not 1:1 with the original
@@ -353,6 +360,7 @@ bool BetterInfo::levelMatchesObject(GJGameLevel* level, const BISearchObject& se
         if(!searchObj.songCustom && level->m_audioTrack != searchObj.songID) return false;
         if(searchObj.songCustom && level->m_songID != searchObj.songID) return false;
     }
+    if(searchObj.ncs && !BetterInfo::isNCSSong(level->m_songID)) return false;
     if(searchObj.copied && level->m_originalLevel <= 0) return false;
         //TODO: searchObj.ldm
 

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -57,6 +57,7 @@ namespace BetterInfo {
 
     BI_DLL std::string getSongUrl(int audioID);
     BI_DLL bool isNewGrounds(int audioID);
+    BI_DLL bool isNCSSong(int audioID);
 
     BI_DLL cocos2d::CCDictionary* responseToDict(std::string_view response);
 


### PR DESCRIPTION
Adds a new filter to the Filtered Level Search menu to show only levels using songs from the NCS library. 

<img width="1920" height="1080" alt="Screenshot 2026-08-02 204420" src="https://github.com/user-attachments/assets/6cf2a69b-c115-4227-afbf-d45e7d60a113" />
<img width="1920" height="1080" alt="Screenshot 2026-08-02 204452" src="https://github.com/user-attachments/assets/080393c3-6bde-46ff-9f51-61789432170d" />
